### PR TITLE
Fix popup not closable

### DIFF
--- a/content.js
+++ b/content.js
@@ -48,10 +48,15 @@ function showDemoPopup() {
   `;
 
   overlay.innerHTML = `
+    <button id="duped-close-btn" style="position:absolute; top:5px; right:5px;">&times;</button>
     <h2>Duped (Demo)</h2>
     <p>This is a public demo. The full version of this extension automatically detects fashion products, scrapes pricing and image data, and finds affordable dupes across stores.</p>
     <p>To see the full version or request access, contact <strong>anukamanghwani@gmail.com</strong>.</p>
   `;
+
+  overlay.querySelector('#duped-close-btn').addEventListener('click', () => {
+    overlay.remove();
+  });
 
   document.body.appendChild(overlay);
 }


### PR DESCRIPTION
## Summary
- add a close button to the demo popup so users can dismiss it

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f67ad5c748321b2ca079dd8ecd7af